### PR TITLE
Removes deprecated flattenImages method

### DIFF
--- a/services/PdfthumbService.php
+++ b/services/PdfthumbService.php
@@ -24,7 +24,7 @@ class PdfthumbService extends BaseApplicationComponent
             $thumb = new Imagick();
             $thumb->setResolution(300, 300);
             $thumb->readImage($element->path . '[0]');  // Read only first page
-            $thumb = $thumb->flattenImages();
+            $thumb = $thumb->mergeImageLayers(Imagick::LAYERMETHOD_FLATTEN);
             $thumb->setImageFormat('jpg');  // Output format
             $thumb->setImageCompression(Imagick::COMPRESSION_JPEG);
             $thumb->setImageCompressionQuality(isset($params['quality']) ? $params['quality'] : 60);


### PR DESCRIPTION
PHP 5.6 and up throws a deprecation warning with the flattenImages method — switched it over to the new approved method.
